### PR TITLE
fix: remove hardcoded version from metadata test

### DIFF
--- a/doc/changelog.d/50.fixed.md
+++ b/doc/changelog.d/50.fixed.md
@@ -1,0 +1,1 @@
+fix: remove hardcoded version from metadata test

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -24,4 +24,13 @@ from ansys.additive.widgets import __version__
 
 
 def test_pkg_version():
-    assert __version__ == "0.1.dev2"
+    try:
+        import importlib.metadata as importlib_metadata
+    except ModuleNotFoundError:  # pragma: no cover
+        import importlib_metadata
+
+    # Read from the pyproject.toml
+    # major, minor, patch
+    read_version = importlib_metadata.version("ansys-additive-widgets")
+
+    assert __version__ == read_version


### PR DESCRIPTION
As the title says