### PR TITLE
fix: change ubuntu-latest-8-cores to public-ubuntu-latest-8-cores

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -118,13 +118,9 @@ jobs:
   doc-build:
     name: "Building library documentation"
     if: github.event_name != 'merge_group'
-    # This is dumb but the schema checker doesn't allow the runner name
-    # `public-ubuntu-latest-8-cores`. Circumvent this by using a matrix
-    # strategy.
-    # [safee 3/27/24] - check github actions to see available runners
     strategy:
       matrix:
-        runner: [ubuntu-latest-8-cores]
+        runner: [public-ubuntu-latest-8-cores]
     runs-on: ${{ matrix.runner }}
     needs: [doc-style]
     steps:

--- a/doc/changelog.d/52.fixed.md
+++ b/doc/changelog.d/52.fixed.md
@@ -1,0 +1,1 @@
+fix: change ubuntu-latest-8-cores to public-ubuntu-latest-8-cores


### PR DESCRIPTION
Changing to public runner should allow documentation job to run