### PR TITLE
chore: allow dev versions of pyadditive

### DIFF
--- a/doc/changelog.d/81.dependencies.md
+++ b/doc/changelog.d/81.dependencies.md
@@ -1,0 +1,1 @@
+chore: allow dev versions of pyadditive

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
   "importlib-metadata >=4.0",
-  "ansys-additive-core >=0.19, <0.20",
+  "ansys-additive-core >=0.19, <0.21",
   "panel==1.4.4",
 ]
 


### PR DESCRIPTION
Hi @pkrull-ansys - I'd recommend that you enabled the usage of dev versions of pyadditive with the widgets repo. Otherwise, if you try to install both projects from source (the main branch), pip will complain.